### PR TITLE
set max size for dog card

### DIFF
--- a/client/src/components/Dog.js
+++ b/client/src/components/Dog.js
@@ -19,7 +19,7 @@ import DogMenu from "./DogMenu";
 const useStyles = makeStyles((theme) => ({
   root: {
     minWidth: 300,
-    maxWidth: 450,
+    maxWidth: 300,
   },
   media: {
     height: 0,


### PR DESCRIPTION
Turned out to just be the dog card max size was set to 450, instead of the same size as the min. Cool magnify effect though.